### PR TITLE
Disable items highlighting on mouse hover in file/project switch dialog

### DIFF
--- a/Numix Dark Blue.sublime-theme
+++ b/Numix Dark Blue.sublime-theme
@@ -782,11 +782,6 @@
     },
     {
         "class": "quick_panel_row",
-        "attributes": ["hover"],
-        "layer0.tint": [55,117,214]
-    },
-    {
-        "class": "quick_panel_row",
         "attributes": ["selected"],
         "layer0.tint": [55,117,214]
     },

--- a/Numix Dark Green.sublime-theme
+++ b/Numix Dark Green.sublime-theme
@@ -782,11 +782,6 @@
     },
     {
         "class": "quick_panel_row",
-        "attributes": ["hover"],
-        "layer0.tint": [55,214,73]
-    },
-    {
-        "class": "quick_panel_row",
         "attributes": ["selected"],
         "layer0.tint": [55,214,73]
     },

--- a/Numix Dark Light Blue.sublime-theme
+++ b/Numix Dark Light Blue.sublime-theme
@@ -782,11 +782,6 @@
     },
     {
         "class": "quick_panel_row",
-        "attributes": ["hover"],
-        "layer0.tint": [55,196,214]
-    },
-    {
-        "class": "quick_panel_row",
         "attributes": ["selected"],
         "layer0.tint": [55,196,214]
     },

--- a/Numix Dark.sublime-theme
+++ b/Numix Dark.sublime-theme
@@ -782,11 +782,6 @@
     },
     {
         "class": "quick_panel_row",
-        "attributes": ["hover"],
-        "layer0.tint": [214,73,55]
-    },
-    {
-        "class": "quick_panel_row",
         "attributes": ["selected"],
         "layer0.tint": [214,73,55]
     },

--- a/Numix.sublime-theme
+++ b/Numix.sublime-theme
@@ -776,11 +776,6 @@
     },
     {
         "class": "quick_panel_row",
-        "attributes": ["hover"],
-        "layer0.tint": [214,73,55]
-    },
-    {
-        "class": "quick_panel_row",
         "attributes": ["selected"],
         "layer0.tint": [214,73,55]
     },


### PR DESCRIPTION
Hi!

I have spotted some inconsistency in project/file switch dialog compared to command palette. Command palette's items is not being highlighted on mouse hover, and that is good thing, unlike an items in project/file switch dialog.

Double highlighting in switch dialog is confusing me every time.

File switch dialog:
![1455803641](https://cloud.githubusercontent.com/assets/1951834/13155830/4832a42c-d688-11e5-9f1f-e4455fed2c87.png)

